### PR TITLE
Add introductory text on the splash screen

### DIFF
--- a/app/app/apps/__init__.py
+++ b/app/app/apps/__init__.py
@@ -13,6 +13,7 @@ from codetiming import Timer
 
 # Geo:N:G imports
 from app import config
+from app.assets import panes
 from app.assets import state
 from geong_common import files
 from geong_common.log import logger
@@ -87,19 +88,33 @@ def view():
 def create_splash(header_canvas, view_canvas, sidebar_menu, **layout_args):
     """Create a splash screen shown when app is starting up
 
-    Use spacers to center button row on screen.
+    Use spacers to center text and button rows on screen.
     """
-    splash_row = pn.Row(pn.layout.HSpacer(), pn.layout.HSpacer(), **layout_args)
+    splash_text = panes.markdown_from_url(
+        CFG.splash.replace("text_url"),
+        sizing_mode="stretch_width",
+        max_width=600,
+        align="center",
+    )
+    splash_buttons = pn.Row(pn.layout.HSpacer(), pn.layout.HSpacer(), **layout_args)
     for app in CFG.apps:
+        if app in CFG.splash.get("exclude_apps", []):
+            continue
         app_button = pn.widgets.Button(name=CFG[app].label)
         app_button.on_click(
             _update_view_factory(
                 header_canvas, view_canvas, sidebar_menu, app, CFG[app].primary_view
             )
         )
-        splash_row.insert(-1, app_button)
+        splash_buttons.insert(-1, app_button)
 
-    return [pn.layout.VSpacer(), splash_row, pn.layout.VSpacer()]
+    return [
+        pn.layout.Spacer(height=30),
+        splash_text,
+        pn.layout.VSpacer(),
+        splash_buttons,
+        pn.layout.VSpacer(),
+    ]
 
 
 def create_menu(header_canvas, view_canvas, **layout_args):

--- a/app/app/assets/instructions/splash_intro.md
+++ b/app/app/assets/instructions/splash_intro.md
@@ -1,0 +1,3 @@
+# Net to Gross Calculator
+
+Welcome to the Net to Gross Calculator. Please choose your workflow from one of the **buttons** below, or from the **menu** on the left.

--- a/app/app/assets/panes.py
+++ b/app/app/assets/panes.py
@@ -197,10 +197,10 @@ def _division_slider_with_3_params(params, param_1, param_2, param_3):
     return spinners, slider
 
 
-def markdown_from_url(url):
+def markdown_from_url(url, **markdown_args):
     """Create a Markdown pane by getting the markdown string from a URL"""
     markdown = files.get_url_or_asset(url, local_assets="app.assets").read_text()
-    return pn.pane.Markdown(markdown)
+    return pn.pane.Markdown(markdown, **markdown_args)
 
 
 def warning(text):

--- a/app/app/config/app.toml
+++ b/app/app/config/app.toml
@@ -55,6 +55,10 @@ apps             = ["deep", "shallow", "instructions"]
 primary_app      = "deep"
 reader           = "api"
 
+    [apps.splash]
+    exclude_apps     = []
+    text_url         = "{ASSET_INSTRUCTIONS}/splash_intro.md"
+
     [apps.deep]
     label            = "Deep Marine"
     views            = ["workflow", "data_viewer"]


### PR DESCRIPTION
Note that anyone hosting their own instructions using `ASSET_INSTRUCTIONS` should add the file `splash_intro.md` that holds the new text shown on the splash page.