### PR TITLE
Render app title in top bar with header color

### DIFF
--- a/app/app/apps/__init__.py
+++ b/app/app/apps/__init__.py
@@ -28,7 +28,9 @@ pn.extension(
     raw_css=[
         files.get_url_or_asset(css, local_assets="app.assets").read_text()
         for css in _STYLE.raw_css
-    ],
+    ]
+    # Workaround to apply header color to app header (Geo:N:G)
+    + [f".title {{color: {_STYLE.header_color} !important;}}"],
     css_files=_STYLE.css_files,
 )
 


### PR DESCRIPTION
This seems like a bug in Panel: The main app title is not colored by the `header_color` variable. This _fix_ enforces it using CSS.