### PR TITLE
Bugfix: Point environment variable REPORT_TEMPLATE correctly

### DIFF
--- a/app/app/config/__init__.py
+++ b/app/app/config/__init__.py
@@ -23,10 +23,15 @@ app.update_from_env(
         "HEADER_BACKGROUND": ("style", "header_background"),
         "HEADER_COLOR": ("style", "header_color"),
         "LOGO": ("style", "logo"),
-        "REPORT_TEMPLATE": ("report", "net_gross_ppt", "template"),
         "READER": ("apps", "reader"),
     },
     converters={"RAW_CSS": "list", "CSS_FILES": "list"},
+)
+
+# Add template to each report
+app.update_from_env({"REPORT_TEMPLATE": ("report", "deep_net_gross_ppt", "template")})
+app.update_from_env(
+    {"REPORT_TEMPLATE": ("report", "shallow_net_gross_ppt", "template")}
 )
 
 # Set up asset hosts


### PR DESCRIPTION
After changing names of report config sections in #44 , `REPORT_TEMPLATE` was no longer pointing to the correct section in the configuration.