### PR TITLE
Revert centering of set-up screen in workflows

### DIFF
--- a/app/app/apps/deep/workflow.py
+++ b/app/app/apps/deep/workflow.py
@@ -32,5 +32,5 @@ def view():
         pipeline.network,
         pipeline.error,
         pipeline.stage,
-        pn.Row(pn.layout.HSpacer(), pipeline.buttons, pn.layout.HSpacer()),
+        pipeline.buttons,
     ]

--- a/app/app/apps/shallow/workflow.py
+++ b/app/app/apps/shallow/workflow.py
@@ -32,5 +32,5 @@ def view():
         pipeline.network,
         pipeline.error,
         pipeline.stage,
-        pn.Row(pn.layout.HSpacer(), pipeline.buttons, pn.layout.HSpacer()),
+        pipeline.buttons,
     ]

--- a/app/app/stages/deep/set_up.py
+++ b/app/app/stages/deep/set_up.py
@@ -94,15 +94,11 @@ class View:
     def panel(self):
         """Display the first stage using radio boxes"""
 
-        return pn.Row(
-            pn.layout.HSpacer(),
-            pn.Column(
-                panes.multiple_choice(self.param.gross_geomorphology),
-                panes.multiple_choice(self.param.stratigraphic_scale),
-                panes.multiple_choice(self.param.reservoir_quality),
-                sizing_mode="stretch_width",
-            ),
-            pn.layout.HSpacer(),
+        return pn.Column(
+            panes.multiple_choice(self.param.gross_geomorphology),
+            panes.multiple_choice(self.param.stratigraphic_scale),
+            panes.multiple_choice(self.param.reservoir_quality),
+            sizing_mode="stretch_width",
         )
 
 

--- a/app/app/stages/shallow/set_up.py
+++ b/app/app/stages/shallow/set_up.py
@@ -92,16 +92,12 @@ class View:
     def panel(self):
         """Display the first stage using radio boxes"""
 
-        return pn.Row(
-            pn.layout.HSpacer(),
-            pn.Column(
-                panes.multiple_choice(self.param.composition_threshold),
-                panes.multiple_choice(self.param.depositional_setting),
-                panes.multiple_choice(self.param.stratigraphic_scale),
-                panes.multiple_choice(self.param.reservoir_quality),
-                sizing_mode="stretch_width",
-            ),
-            pn.layout.HSpacer(),
+        return pn.Column(
+            panes.multiple_choice(self.param.composition_threshold),
+            panes.multiple_choice(self.param.depositional_setting),
+            panes.multiple_choice(self.param.stratigraphic_scale),
+            panes.multiple_choice(self.param.reservoir_quality),
+            sizing_mode="stretch_width",
         )
 
 


### PR DESCRIPTION
Reverts some of the formatting done in #37